### PR TITLE
FEA-881 pass version + lang

### DIFF
--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,0 +1,2 @@
+instrumentation:
+  include-all-sources: true

--- a/circle.yml
+++ b/circle.yml
@@ -5,16 +5,16 @@ dependencies:
   pre:
     - npm install git+ssh://git@github.com:holidayextras/deployment-helpers.git
     - node_modules/deployment-helpers/nodeApps/preRelease.sh
-    - npm install grunt grunt-cli istanbul mocha -g
 test:
   pre:
     - mkdir -p $CIRCLE_TEST_REPORTS/unit
     - mkdir -p $CIRCLE_TEST_REPORTS/coverage
   override:
-    - node_modules/.bin/make-up lib test
-    - istanbul cover _mocha --  --timeout 15000 --recursive test/**/*Test.js -R xunit > $CIRCLE_TEST_REPORTS/unit/results.xml
+    - npm run lint
+    - npm run ci
   post:
     - cp -r ./coverage/ $CIRCLE_ARTIFACTS/coverage
+    - echo "$GRAPHITE_API_KEY.counters.$CIRCLE_PROJECT_REPONAME.production.test.coverage `./node_modules/.bin/coverage-percentage ./coverage/lcov.info --lcov`" | nc -uw0 carbon.hostedgraphite.com 2003
 deployment:
   production:
     branch: master

--- a/index.js
+++ b/index.js
@@ -1,3 +1,0 @@
-'use strict';
-
-module.exports = require( './lib/pluginTapestry.js' );

--- a/lib/pluginTapestry.js
+++ b/lib/pluginTapestry.js
@@ -114,18 +114,17 @@ exports.register = function( server, pluginOptions, next ) {
       }
 
       // Make a singular tapestry request with the ids
-      tapestry.get( { ids: options.ids, identifier: options.identifier }, function( tapestryError, result ) {
-        // Add the returned result as a content object under the original detected node.
-        if ( !_.isUndefined( result ) && result.length > 0 ) {
-          deferred.resolve( result );
-        } else {
+      var cleanOptions = _.pick(options, ['identifier', 'ids', 'lang', 'version']);
+      tapestry.get(cleanOptions, function(tapestryError, result) {
+        if (tapestryError || !result || !result.length) {
           deferred.reject( {
-            error: new Error( 'no results returned from Tapestry' ),
+            error: new Error('no results from Tapestry'),
             origin: pluginName,
             data: options
           } );
+        } else {
+          deferred.resolve(result);
         }
-
       } );
 
     } catch ( error ) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-tapestry",
   "description": "A hapijs plugin to interface Tapestry",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "homepage": "https://github.com/holidayextras/plugin-tapestry",
   "author": {
     "name": "Shortbreaks",
@@ -12,28 +12,33 @@
     "url": "git@github.com:holidayextras/plugin-tapestry.git"
   },
   "license": "MIT",
-  "main": "index",
+  "main": "lib/pluginTapestry",
   "engines": {
     "node": ">= 0.10.0"
   },
   "scripts": {
-    "test": "node_modules/deployment-helpers/nodeApps/preRelease.sh && node_modules/.bin/make-up lib test && istanbul cover _mocha -- --recursive -R spec"
+    "ci": "node_modules/.bin/istanbul cover _mocha -- -R xunit > $CIRCLE_TEST_REPORTS/unit/results.xml",
+    "lint": "node_modules/.bin/make-up lib test",
+    "prerelease": "node_modules/deployment-helpers/nodeApps/preRelease.sh",
+    "test": "npm run prerelease && npm run lint && istanbul cover _mocha"
   },
   "dependencies": {
-    "tapestry": "git+ssh://git@github.com:holidayextras/tapestry.git#v1.3.1",
+    "tapestry": "git+ssh://git@github.com:holidayextras/tapestry.git#v1.4.0",
     "tapestry-exodus": "git+ssh://git@github.com:holidayextras/tapestry-exodus.git#v1.1.2",
-    "tapestry-prismic": "git+ssh://git@github.com:holidayextras/tapestry-prismic.git#v1.2.0",
+    "tapestry-prismic": "git+ssh://git@github.com:holidayextras/tapestry-prismic.git#v1.3.0",
     "lodash": "2.4.1",
     "q": "1.0.1"
   },
   "devDependencies": {
-    "chai": "1.9.1",
-    "chai-as-promised": "4.3.0",
+    "chai": "^3.5.0",
+    "chai-as-promised": "^5.3.0",
+    "coverage-percentage": "0.0.2",
     "deployment-helpers": "git+ssh://git@github.com:holidayextras/deployment-helpers.git",
     "hapi": "6.0.2",
     "istanbul": "0.3.7",
     "make-up": "6.0.0",
     "mocha": "1.20.1",
-    "sinon": "1.12.2"
+    "sinon": "1.12.2",
+    "sinon-chai": "^2.8.0"
   }
 }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--timeout 15000
+--recursive
+--reporter spec


### PR DESCRIPTION
#### What are the links to relevant tickets?

https://hxshortbreaks.atlassian.net/browse/WEB-7490

#### What does this PR do?
 - pass lang and version in to tapestry-prismic
 - improve error handling
 - add coverage reporting to ci

#### What functional/unit tests does this PR have?
```
pluginTapestry
  #makeItSo
    with extra params
      ✓ should pick the correct params 
      ✓ should pass only certain params on to tapestry 
```
#### Is there anything a developer should be aware of when reviewing this?

Mostly it is changes to the CI, the important bit is

```
var cleanOptions = _.pick(options, ['identifier', 'ids', 'lang', 'version']);
tapestry.get(cleanOptions, function(tapestryError, result) {
if (tapestryError || !result || !result.length) {
```
 - we're now sending lang and version if we get it
 - we're now handling any error we get from tapestry

To see it in action best to checkout out the-works branch FEA-881 and see the examples on https://hxshortbreaks.atlassian.net/browse/WEB-7490

---
#### Quality checklist (for PR author to complete BEFORE code review):
- [x] I've checked there is appropriate unit test coverage.
- [ ] I've updated documentation with any changes to procedures.
- [x] I've checked this work against the requirements of the Jira.
- [x] This change passes all necessary tests (cross browser, automated or otherwise).
- [x] I am ready for this to be code reviewed, merged and tested.

#### Reviewer 1 @notABluesSinger
- [x] I agree with the assumptions made in the quality checklist.
- [ ] I’ve witnessed the work behaving as expected.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked for coding anti-patterns.
- [x] I've checked this work against the requirements of the Jira.
- [x] I don’t believe this work introduces unnecessary technical debt.
- [x] +1 from me!

#### Reviewer 2 @t1gr0u
- [x] I agree with the assumptions made in the quality checklist.
- [ ] I’ve witnessed the work behaving as expected.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked for coding anti-patterns.
- [x] I've checked this work against the requirements of the Jira.
- [x] I don’t believe this work introduces unnecessary technical debt.
- [x] +1 from me!