### PR TITLE
web10811 - change to use tapestry prismic version with product type s…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-tapestry",
   "description": "A hapijs plugin to interface Tapestry",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "homepage": "https://github.com/holidayextras/plugin-tapestry",
   "author": {
     "name": "Shortbreaks",
@@ -27,7 +27,7 @@
   "dependencies": {
     "tapestry": "git+ssh://git@github.com:holidayextras/tapestry.git#v1.4.0",
     "tapestry-exodus": "git+ssh://git@github.com:holidayextras/tapestry-exodus.git#v2.0.0",
-    "tapestry-prismic": "git+ssh://git@github.com:holidayextras/tapestry-prismic.git#v1.7.1",
+    "tapestry-prismic": "git+ssh://git@github.com:holidayextras/tapestry-prismic.git#v1.8.0",
     "lodash": "4.17.4",
     "q": "1.4.1"
   },


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
https://hxshortbreaks.atlassian.net/browse/WEB-10811
Orders the related products like hotel, hotelPackage, hotelBrand in the required order spicified in the config for the product type  so we get the right values back when they are merged . this work has been done in tapestry prismic pulling in that version of tapestry-prismic

#### What tests does this PR have?

#### How can this be tested?
it tested when the works work to get the hotel package information for the extra night promotion is PR'ed

#### Any tech debt?
nope

- I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

By approving a review you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

---
