### PR TITLE
Stopping logging

### DIFF
--- a/lib/pluginTapestry.js
+++ b/lib/pluginTapestry.js
@@ -195,7 +195,8 @@ exports.register = function( server, pluginOptions, next ) {
   // where to log messages
   var config = server.methods.getService( 'tapestry' );
   config.cache = server.methods.getConfig().cache;
-  config.logger = server.methods.getDataLoggingWrapper( 'tapestry' );
+  // We've seen reqwuests logging ~500Kb to loggly with the Tapestry logging turned on, this when multiplied by the 22k packageRates requests, is filling up loggly and providing no value. Please carefully consider before enabling the logger.
+  // config.logger = server.methods.getDataLoggingWrapper( 'tapestry' );
 
   // Create a new Tapestry object based on the resulting configuration
   var promise = new Tapestry( config );

--- a/lib/pluginTapestry.js
+++ b/lib/pluginTapestry.js
@@ -195,7 +195,7 @@ exports.register = function( server, pluginOptions, next ) {
   // where to log messages
   var config = server.methods.getService( 'tapestry' );
   config.cache = server.methods.getConfig().cache;
-  // We've seen reqwuests logging ~500Kb to loggly with the Tapestry logging turned on, this when multiplied by the 22k packageRates requests, is filling up loggly and providing no value. Please carefully consider before enabling the logger.
+  // We've seen requests logging ~500Kb to loggly with the Tapestry logging turned on, this when multiplied by the 22k packageRates requests, is filling up loggly and providing no value. Please carefully consider before enabling the logger.
   // config.logger = server.methods.getDataLoggingWrapper( 'tapestry' );
 
   // Create a new Tapestry object based on the resulting configuration

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-tapestry",
   "description": "A hapijs plugin to interface Tapestry",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "homepage": "https://github.com/holidayextras/plugin-tapestry",
   "author": {
     "name": "Shortbreaks",


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
[WEB-10996](https://hxshortbreaks.atlassian.net/browse/WEB-10996)
Stops sending extra Tapestry logs to loggly.
#### What tests does this PR have?
No new
#### How can this be tested?
Check the output of the logging function in The Works
#### Any tech debt?
Left the code commented out, but the idea is to prevent it being re-enabled
#### Screenshots / Screencast
N/A
#### What gif best describes how you feel about this work?
![](https://media.giphy.com/media/yUrUb9fYz6x7a/giphy.gif)

- I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

By approving a review you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

---
