### PR TITLE
Version bump on Tapestry-prismic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-tapestry",
   "description": "A hapijs plugin to interface Tapestry",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "homepage": "https://github.com/holidayextras/plugin-tapestry",
   "author": {
     "name": "Shortbreaks",
@@ -27,7 +27,7 @@
   "dependencies": {
     "tapestry": "git+ssh://git@github.com:holidayextras/tapestry.git#v1.4.0",
     "tapestry-exodus": "git+ssh://git@github.com:holidayextras/tapestry-exodus.git#v2.0.0",
-    "tapestry-prismic": "git+ssh://git@github.com:holidayextras/tapestry-prismic.git#v1.8.0",
+    "tapestry-prismic": "git+ssh://git@github.com:holidayextras/tapestry-prismic.git#v1.9.0",
     "lodash": "4.17.4",
     "q": "1.4.1"
   },


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
https://hxshortbreaks.atlassian.net/browse/WEB-10748
Updates version of Tapestry-Prismic (see https://github.com/holidayextras/tapestry-prismic/pull/18)

#### What tests does this PR have?
#### How can this be tested?
Best to run with https://github.com/holidayextras/themeBlueprint/pull/885.

#### Any tech debt?
#### Screenshots / Screencast=
#### What gif best describes how you feel about this work?

- I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

By approving a review you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

---
